### PR TITLE
[vim] Adds <C-,> -- duplicate lines that acts like own emacs function

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -20,5 +20,7 @@ set imsearch=0
 set autoindent
 colorscheme koehler
 
+:nnoremap <C-,> :t.<CR>
+
 autocmd BufEnter * if &filetype == "go" | setlocal noexpandtab
 autocmd BufNewFile,BufRead ?\+.c3 setf c


### PR DESCRIPTION
Inspired by your's "Configuring Emacs on My New Laptop" video. 

It is vim alternative to your 'rc/duplicate-line' Emacs command.